### PR TITLE
refactor example

### DIFF
--- a/assets/javascripts/correct_post.js
+++ b/assets/javascripts/correct_post.js
@@ -1,17 +1,13 @@
 Discourse.PostMenuView.reopen({
-  shouldRerenderCorrectButton: Discourse.View.renderIfChanged("post.correctPostId"),
+  shouldRerenderCorrectButton: Discourse.View.renderIfChanged("post.topic.correct_post_id"),
 
   renderCorrect: function(post, buffer) {
-    var correctPostId = post.getWithDefault("correctPostId", this.get("post.topic.correct_post_id"));
-    
-    if (correctPostId && this.get("post.id") == correctPostId) {
+    var correctPostId = post.get("topic.correct_post_id");
+
+    if (correctPostId && post.get("id") === parseInt(correctPostId, 10)) {
       buffer.push("<div id='correct-text'>This post was marked as correct</div>");
-      var postNumber = this.get("post.post_number");
-      setTimeout(function() {
-        $("#post_" + postNumber + " .topic-body").addClass("correct-post");
-      }, 250);
     } else {
-      if (this.get("post.topic.details.can_edit")) {
+      if (post.get("topic.details.can_edit")) {
         buffer.push('<button title="Mark this post as solving your initial question" data-action="correct">Mark as correct</button>');
       }
     }
@@ -19,8 +15,6 @@ Discourse.PostMenuView.reopen({
 
   clickCorrect: function() {
     this.get('controller').markSolved(this.get("post"));
-    $(".correct-post").removeClass("correct-post");
-    $("#correct-text").replaceWith('<button title="Mark this post as solving your initial question" data-action="correct">Mark as correct</button>');
-    this.set("post.correctPostId", this.get("post.id"));
+    this.set("post.topic.correct_post_id", this.get("post.id"));
   }
 });

--- a/assets/javascripts/post_view_cont.js
+++ b/assets/javascripts/post_view_cont.js
@@ -1,0 +1,12 @@
+Discourse.PostView.reopen({
+  classNameBindings: ['postTypeClass',
+                      'selected',
+                      'post.hidden:deleted',
+                      'post.deleted',
+                      'correctClass'],
+
+  correctClass: function() {
+    var correctPostId = this.get('post.topic.correct_post_id');
+    if (correctPostId && parseInt(correctPostId) === this.get('post.id')) { return "correct-post"; }
+  }.property('post.topic.correct_post_id', 'post.id')
+});

--- a/plugin.rb
+++ b/plugin.rb
@@ -5,6 +5,7 @@
 register_asset "javascripts/correct_post.js"
 register_asset "javascripts/topic_cont.js"
 register_asset "javascripts/topic_controller_cont2.js"
+register_asset "javascripts/post_view_cont.js"
 register_asset "stylesheets/correct_post.css.scss"
 
 after_initialize do


### PR DESCRIPTION
Since the `correct_post_id` is an attribute of the topic, you should rerender the correct button whenever it changes instead of copying it to the post model.

NOTE: the code does not test if something went wrong server-side.

There are several ways to keep the UI up to date. In this PR I reopened the `PostView` and added a new `classNameBinding`. Another solution would be to have a `isCorrect` property on the `Post` model (that would check the id of the post against the correct_post_id of the topic) and update the post template accordingly.
